### PR TITLE
Mark correct question even if user clicked wrong

### DIFF
--- a/src/components/Quiz.jsx
+++ b/src/components/Quiz.jsx
@@ -67,6 +67,8 @@ const Quiz = () => {
       dispatch(increaseCorrectAnswers());
     } else {
       answerRefs.current[index].classList.add('wrong');
+      const correct = answerRefs.current.find(answer => answer.textContent === currentQuestion.correct_answer);
+      correct.classList.add('correct');
       dispatch(increaseIncorrectAnswers());
     }
     setTimeout(() => {
@@ -76,7 +78,7 @@ const Quiz = () => {
       }
       dispatch(setCurrentIndex());
       dispatch(setCurrentQuestion());
-    }, 1000)
+    }, 1500)
   }
   
   return (


### PR DESCRIPTION
Closes #24 

This PR add functionality to mark the correct answer even if user clicked on a wrong one.

This way user knows immediately whether they answered correctly.