### PR TITLE
search for correct based on name attribute not text content

### DIFF
--- a/src/components/Quiz.jsx
+++ b/src/components/Quiz.jsx
@@ -72,7 +72,7 @@ const Quiz = () => {
       dispatch(increaseCorrectAnswers());
     } else {
       answerRefs.current[index].classList.add('wrong');
-      const correct = answerRefs.current.find(answer => answer.textContent === currentQuestion.correct_answer);
+      const correct = answerRefs.current.find(answer => answer.getAttribute('name') === 'true');
       correct.classList.add('correct');
       dispatch(increaseIncorrectAnswers());
     }


### PR DESCRIPTION
Closes #31 

This PR changes the way I find a correct answer to mark.

Instead of using textContent I used name attribute to find it and compare it.